### PR TITLE
Specify extra keys when loading spine mesh

### DIFF
--- a/ca2+-examples/dendritic_spine.ipynb
+++ b/ca2+-examples/dendritic_spine.ipynb
@@ -151,7 +151,7 @@
     "    name=\"parent_mesh\",\n",
     ")\n",
     "\n",
-    "geo = mesh_tools.load_mesh(filename=args[\"mesh_file\"], extra_keys=["subdomain0_2", "subdomain1_3"])\n",
+    "geo = mesh_tools.load_mesh(filename=args[\"mesh_file\"], extra_keys=[\"subdomain0_2\", \"subdomain1_3\"])\n",
     "subdomain0 = geo.subdomains[0]\n",
     "subdomain1 = geo.subdomains[1]\n",
     "ds = d.Measure(\"ds\", domain=geo.mesh, subdomain_data=subdomain0)\n",


### PR DESCRIPTION
This should be used with the updated version of mesh_tools in the SMART repo